### PR TITLE
Temporary compatibility fix for THCC imports.

### DIFF
--- a/model_converter/converter/app/gui/main_window.py
+++ b/model_converter/converter/app/gui/main_window.py
@@ -3,8 +3,11 @@ import tkinter as tk
 from tkinter import ttk, Toplevel
 from tkinter.filedialog import askopenfilename
 from model_converter.converter.app.util import get_root_path
-
-from typhoon.api.schematic_editor import SchApiException
+try:
+    from typhoon.api.schematic_editor import SchApiException
+# Temporary fix for namespace clashing in THCC
+except ImportError:
+    from typhoon.api.impl.schematic_editor import SchApiException
 
 from model_converter.converter.app.converter import Converter
 

--- a/model_converter/converter/parsers/base_parser.py
+++ b/model_converter/converter/parsers/base_parser.py
@@ -18,7 +18,11 @@ from model_converter.converter.app.util import get_root_path
 class BaseParser:
 
     def __init__(self):
-        from typhoon.api.schematic_editor import model as mdl
+        try:
+            from typhoon.api.schematic_editor import model as mdl
+        # Temporary fix for namespace clashing in THCC
+        except ImportError:
+            from typhoon.api.impl.schematic_editor import model as mdl
         self.mdl = mdl
 
         self.rule_file_path = None
@@ -463,7 +467,12 @@ class BaseParser:
 
 
     def _save_single_component(self, component, parent=None):
-        from typhoon.api.schematic_editor.exception import SchApiException
+        try:
+            from typhoon.api.schematic_editor.exception import SchApiException
+        # Temporary fix for namespace clashing in THCC
+        except ImportError:
+            from typhoon.api.impl.schematic_editor.exception import \
+                SchApiException
         component.parent = parent
         component_handle = \
             self.mdl.create_component(
@@ -514,7 +523,12 @@ class BaseParser:
         return component_handle
 
     def save_component(self, component, parent=None):
-        from typhoon.api.schematic_editor.exception import SchApiException
+        try:
+            from typhoon.api.schematic_editor.exception import SchApiException
+        # Temporary fix for namespace clashing in THCC
+        except ImportError:
+            from typhoon.api.impl.schematic_editor.exception import \
+                SchApiException
         if isinstance(component, SubsystemDataHolder):
             component_handle = \
                 self.mdl.create_component(component.typhoon_type,
@@ -771,7 +785,12 @@ class BaseParser:
         Returns:
             None
         """
-        from typhoon.api.schematic_editor.exception import SchApiException
+        try:
+            from typhoon.api.schematic_editor.exception import SchApiException
+        # Temporary fix for namespace clashing in THCC
+        except ImportError:
+            from typhoon.api.impl.schematic_editor.exception import \
+                SchApiException
         junction = None
         # Checking if a junction should be used to connect
         # terminals from this node list


### PR DESCRIPTION
Temp fix consists of try - except ImportError blocks around each typhoon.api.schematic_editor import. This is needed because of namespace clashing within THCC (when the converter is used internally).